### PR TITLE
fix capital name for linux system

### DIFF
--- a/cmake/FindVORBIS.cmake
+++ b/cmake/FindVORBIS.cmake
@@ -11,7 +11,7 @@ if(VORBIS_INCLUDE_DIR)
     set(VORBIS_FIND_QUIETLY TRUE)
 endif(VORBIS_INCLUDE_DIR)
 
-find_package(Ogg)
+find_package(OGG)
 if(OGG_FOUND)
 	find_path(VORBIS_INCLUDE_DIR vorbis/vorbisfile.h)
 	# MSVC built vorbis may be named vorbis_static


### PR DESCRIPTION
**find_package(Ogg)** searches for **FindOgg.cmake**  but we got **FindOGG.cmake**

I am using Ubuntu 16.04